### PR TITLE
ENH: Support native docker containers for linux/arm64

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,6 @@ services:
 
   # BUILD-ONLY: DE simulation (profile: sim_method)
   de-method:
-    platform: linux/amd64
     build:
       context: ./simulation-backend
       dockerfile: de_method/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,6 @@ services:
 
   # BUILD-ONLY: pyroomacoustics simulation (profile: sim_method)
   pyroomacoustics-method:
-    platform: linux/amd64
     build:
       context: ./simulation-backend
       dockerfile: pyroomacoustics_method/Dockerfile


### PR DESCRIPTION
### Proposed changes
The updated simulation-backend Dockerfile supports for native Docker containers for linux/arm64.
See https://github.com/choras-org/simulation-backend/pull/17