### PR TITLE
DOCS: Add method settings examples to 

### DIFF
--- a/docs/source/includes/contributing/configuring.rst
+++ b/docs/source/includes/contributing/configuring.rst
@@ -4,9 +4,43 @@ Integrating a new Method
 Add Example Settings
 --------------------
 
-Add a JSON file describing your method's adjustable parameters in ``example_settings/``. This will be used by the frontend to generate the UI for the method. Follow the format of ``mynewmethod_setting.json``.
+Add a JSON file describing your method's adjustable parameters in ``example_settings/``.
+This will be used by the frontend to generate the UI for the method.
 
-This file would have the following structure:
+This file is required to follow the following example structure.
+Explanations of each field are provided below:
+
+.. code-block:: json
+
+    {
+        "type": "SimulationSettings",
+        "options": [
+            {
+                "name": "MyNewMethod parameter 1",
+                "description": "This is the most important setting, but does nothing.",
+                "id": "mnm_setting_1",
+                "type": "float",
+                "display": "text",
+                "min": 0.0,
+                "max": 100.0,
+                "default": 50.0,
+                "step": 0.1,
+                "endAdornment": ""
+            },
+            {
+                "name": "MyNewMethod parameter 2",
+                "description": "This is another setting for MyNewMethod.",
+                "id": "mnm_setting_2",
+                "type": "int",
+                "display": "text",
+                "min": 1,
+                "max": 10,
+                "default": 5,
+                "step": 1,
+                "endAdornment": ""
+            }
+        ]
+    }
 
 - At the top level there would be an object with the two fields:
 
@@ -15,12 +49,13 @@ This file would have the following structure:
 
 - Each object in that array describes one configurable parameter and uses the following fields:
 
-  - ``name``: Human-readable label shown in the UI, e.g. ``"MyNewMethod parameter 1"``
-  - ``id``: Internal identifier used in backend/frontend logic, e.g. ``"mnm_1"``. This must be unique per method.
-  - ``type``: Data type of the parameter value, e.g. ``"float"`` (other types can be added if the system supports them, such as ``"int"``, ``"bool"``, ``"string"``).
+  - ``name``: Human-readable label shown in the UI, It should be short and concise, but descriptive enough for users to understand what the parameter does.``
+  - ``description``: Human-readable description shown in the UI via a tooltip. This can be used for longer explanations of the parameter, its purpose, and how it affects the simulation."``
+  - ``id``: Internal identifier used in backend/frontend logic. It must be unique per method.
+  - ``type``: Data type of the parameter value. Supported include (but are not limited to) ``"float"``, ``"int"``, ``"bool"``, and ``"string"``.
   - ``display``: How this parameter is rendered in the UI, e.g. ``"text"`` for a text/number input field (could be other widgets if supported, such as sliders, dropdowns, etc.).
-  - ``min``: Minimum allowed value for numeric types. Used for validation and UI constraints.
-  - ``max``: Maximum allowed value for numeric types. Also used for validation and UI constraints.
+  - ``min``: Minimum allowed value for numeric types. Used for validation and UI constraints. Note that this is not a hard limit, and the backend should also validate the value.
+  - ``max``: Maximum allowed value for numeric types. Also used for validation and UI constraints. Note that this is not a hard limit, and the backend should also validate the value.
   - ``default``: Default value if the user does not provide one. Can be ``null`` if you want to force the user or backend to set it explicitly.
   - ``step``: Increment used in the UI for numeric inputs (e.g. how much the value changes when the user uses arrow keys or a slider).
   - ``endAdornment`` *(optional)*: Optional string shown next to the field in the UI, often for units (e.g. ``"dB"``, ``"m"``, ``"s"``). Empty string if not needed.
@@ -28,9 +63,26 @@ This file would have the following structure:
 Update Method Configuration
 ---------------------------
 
-Update the file ``methods-config.json`` in the ``simulation-backend`` directory with a new entry.
+To allow CHORAS to recognize the newly added method,  add a new entry to the ``methods-config.json`` in the ``simulation-backend`` directory.
+This file lists all available simulation methods.
 
-This file lists all available simulation methods, so CHORAS can recognize yours.
+The following structure is required for a new entry. Descriptions of each field are provided below the example:
+
+.. code-block:: json
+
+    {
+        "simulationType": "mynew_method",
+        "containerImage": "mynew_image:latest",
+        "envVars": {
+            "MYNEW_ENV_VAR": "value"
+        },
+        "label": "My New Method",
+        "entryFile": "mynew_method_entry.py",
+        "setting": "mynew_method_settings.json",
+        "repositoryURL": "https://github.com/myusername/mynew_method",
+        "documentationURL": "https://mynewmethod.readthedocs.io"
+    }
+
 
 - ``simulationType``: The short name of the simulation acting as an identifier
 - ``containerImage``: Name for the container image to be made


### PR DESCRIPTION
Add examples to json files for configuring
- simulation settings
- simulation methods

Added the description (tooltip content) parameter to the documentation.