### PR TITLE
FEAT: Add misuka and sparrowpy as simulation methods

### DIFF
--- a/CHORAS_BUILD.bat
+++ b/CHORAS_BUILD.bat
@@ -22,6 +22,11 @@ docker save -o backend\app\services\executors\pyroomacoustics_image.tar pyroomac
 if errorlevel 1 goto :error
 echo Docker image exported to pyroomacoustics_image.tar
 
+echo Exporting sparrowpy_image:latest to backend\app\services\executors\sparrowpy_image.tar...
+docker save -o backend\app\services\executors\sparrowpy_image.tar sparrowpy_image:latest
+if errorlevel 1 goto :error
+echo Docker image exported to sparrowpy_image.tar
+
 echo Starting Docker Compose...
 docker compose up
 if errorlevel 1 goto :error

--- a/CHORAS_BUILD.sh
+++ b/CHORAS_BUILD.sh
@@ -17,4 +17,7 @@ echo "Docker image exported to pyroomacoustics_image.tar"
 docker save -o backend/app/services/executors/sparrowpy_image.tar sparrowpy_image:latest
 echo "Docker image exported to sparrowpy_image.tar"
 
+docker save -o backend/app/services/executors/misuka_image.tar misuka_image:latest
+echo "Docker image exported: misuka_image.tar"
+
 docker compose up

--- a/CHORAS_BUILD.sh
+++ b/CHORAS_BUILD.sh
@@ -14,4 +14,7 @@ echo "Docker image exported to de_image.tar"
 docker save -o backend/app/services/executors/pyroomacoustics_image.tar pyroomacoustics_image:latest
 echo "Docker image exported to pyroomacoustics_image.tar"
 
+docker save -o backend/app/services/executors/sparrowpy_image.tar sparrowpy_image:latest
+echo "Docker image exported to sparrowpy_image.tar"
+
 docker compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,5 +75,15 @@ services:
     profiles:
       - sim_method # Skipped in docker compose up
 
+  # BUILD-ONLY: sparrowpy simulation (profile: sim_method)
+  sparrowpy-method:
+    platform: linux/amd64
+    build:
+      context: ./simulation-backend
+      dockerfile: sparrowpy_method/Dockerfile
+    image: sparrowpy_image:latest
+    profiles:
+      - sim_method # Skipped in docker compose up
+
 volumes:
   postgresql_data:


### PR DESCRIPTION
Add misuka and sparrowpy as simulation methods

- Add to docker compose
- Add to build/export scripts
- Update simulation-backend sub repository