### PR TITLE
DOC: Add contribution guidlines for versioning and releasing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,0 +1,12 @@
+=======
+History
+=======
+
+Unreleased
+----------
+
+
+0.1.0 (2025-11-04)
+------------------
+
+Version of CHORAS used at ASSA 2025.

--- a/docs/source/includes/contributing.rst
+++ b/docs/source/includes/contributing.rst
@@ -22,6 +22,7 @@ The following steps will help you navigate the process.
    contributing/backend/documentation.rst
    contributing/backend/testing.rst
    contributing/backend/setup_dev.rst
+   contributing/backend/releasing.rst
 
 .. toctree::
    :caption: Contributing a new simulation method
@@ -30,6 +31,7 @@ The following steps will help you navigate the process.
    contributing/simulation_method/setup_dev.rst
    contributing/simulation_method/contribute_method.rst
    contributing/simulation_method/configuring.rst
+   contributing/simulation_method/releasing.rst
 
 .. toctree::
    :caption: Contributing to the frontend

--- a/docs/source/includes/contributing.rst
+++ b/docs/source/includes/contributing.rst
@@ -30,3 +30,10 @@ The following steps will help you navigate the process.
    contributing/simulation_method/setup_dev.rst
    contributing/simulation_method/contribute_method.rst
    contributing/simulation_method/configuring.rst
+
+.. toctree::
+   :caption: Contributing to the frontend
+   :maxdepth: 1
+
+   contributing/frontend/setup_dev.rst
+   contributing/frontend/releasing.rst

--- a/docs/source/includes/contributing/backend/releasing.rst
+++ b/docs/source/includes/contributing/backend/releasing.rst
@@ -10,7 +10,7 @@ When preparing for a new major or minor release, please merge the dev branch int
 Patch releases are directly made on the main branch without merging from dev.
 The following steps are then required to prepare a new release:
 
-- Make sure that the changelog in HISTORY.rst is up to date and update if neccessary.
+- Make sure that the changelog in ``HISTORY.rst`` is up to date and update if necessary.
 - Commit all required changes.
 - Run the test suite and ensure that all tests pass.
 

--- a/docs/source/includes/contributing/backend/releasing.rst
+++ b/docs/source/includes/contributing/backend/releasing.rst
@@ -1,0 +1,48 @@
+Release Workflow
+================
+
+A reminder for the maintainers on how to release a new version.
+
+Prepare the release
+~~~~~~~~~~~~~~~~~~~
+
+When preparing for a new major or minor release, please merge the dev branch into main.
+Patch releases are directly made on the main branch without merging from dev.
+The following steps are then required to prepare a new release:
+
+- Make sure that the changelog in HISTORY.rst is up to date and update if neccessary.
+- Commit all required changes.
+- Run the test suite and ensure that all tests pass.
+
+Incrementing the version number
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The CHORAS backend uses `bump-my-version <https://pypi.org/project/bump-my-version/>`_ to manage version numbers.
+For more information on the versioning scheme, please refer to the `versioning section <../general/releasing.html#versioning>`_ in the general contributing guidelines
+
+To increment the version number (can be major, minor, or patch), run the following commands:
+
+.. code-block:: console
+
+   $ bump-my-version bump patch --verbose
+
+
+This will update the version number in all required files and create a git tag for the new version.
+The --verbose flag will output all files that were changed.
+
+Publishing the new version
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Finally, the tag needs to be pushed to the remote repository via:
+
+.. code-block:: console
+
+   $ git push --follow-tags
+
+
+Afterwards, the test suite will automatically be run remotely.
+
+Post-release steps
+~~~~~~~~~~~~~~~~~~
+
+After the release is published, please make sure to merge the main branch back into develop.

--- a/docs/source/includes/contributing/frontend/releasing.rst
+++ b/docs/source/includes/contributing/frontend/releasing.rst
@@ -1,0 +1,59 @@
+Releasing
+=========
+
+Versioning is handled by `standard-version
+<https://github.com/conventional-changelog/standard-version>`_, driven by
+`Conventional Commits <https://www.conventionalcommits.org/>`_. It bumps the
+version in ``package.json``, updates ``CHANGELOG.md``, and creates a
+``chore(release): X.Y.Z`` commit and a matching ``vX.Y.Z`` git tag.
+
+Commit messages
+----------------
+
+Use Conventional Commits so the release script can determine the version
+bump automatically:
+
+- ``fix: ...`` -> patch release
+- ``feat: ...`` -> minor release
+- ``feat: ...`` with a ``BREAKING CHANGE:`` footer -> major release
+
+This strategy is based on semantic versioning, see the `versioning section <../general/releasing.html#versioning>`_ in the general contributing guidelines.
+
+Cutting a release
+------------------
+
+Run from ``frontend-v2``, on the branch you want to release from:
+
+.. code-block:: bash
+
+   npm run release:dry   # preview the version bump and changelog, no changes
+   npm run release       # bump version, update changelog, commit, tag
+
+Force a specific bump instead of the auto-detected one with
+``release:patch``, ``release:minor``, or ``release:major``.
+
+To release an exact version instead of a bump level, pass it directly:
+
+.. code-block:: bash
+
+   npm run release -- --release-as 1.2.3
+
+**Then push both the commit and the tag:**
+
+.. code-block:: bash
+
+   git push --follow-tags
+
+A plain ``git push`` does **not** push tags. Forgetting ``--follow-tags`` is
+the most common mistake here — it leaves the release commit on the remote
+but the tag only on your machine, silently breaking the changelog's compare
+links and anyone else's ability to check out that version.
+
+Notes
+-----
+
+- There is no CI automation for releases (no release workflow, no
+  post-commit hook). The steps above are entirely manual.
+- The Docker image build (``.github/workflows/docker-build.yml``) is
+  independent of app versioning: it always publishes ``:latest`` on push to
+  ``dev`` and does not consume the semver tag.

--- a/docs/source/includes/contributing/frontend/setup_dev.rst
+++ b/docs/source/includes/contributing/frontend/setup_dev.rst
@@ -1,0 +1,70 @@
+Setting up your development environment
+=======================================
+
+Forking the repository
+----------------------
+
+Ready to contribute? Here's how to set up your development environment for CHORAS.
+We always recommend creating a `fork <https://docs.github.com/en/get-started/quickstart/fork-a-repo/>`_ of the repository you would like to contribute to.
+This allows you to freely develop and test your changes without affecting the main repository until you're ready to submit a pull request.
+
+1. Fork the repository you want to contribute to (e.g., `choras-org/frontend-v2 <https://github.com/choras-org/frontend-v2>`_). Please make sure that you enable giving maintainers access to your fork, so we can help you if you run into issues.
+2. Clone your forked main repository to your local machine:
+
+   .. code-block:: bash
+
+      git clone https://github.com/<your-username>/CHORAS
+      cd CHORAS
+
+   If you only want to contribute to the frontend/backend, you can instead clone the original repository.
+
+3. Navigate into the CHORAS directory and initialize the three (``frontend-v2``, ``backend``, and ``simulation-backend``) submodules:
+
+   .. code-block:: bash
+
+      cd CHORAS
+      git submodule update --init --recursive
+
+4. Update the remote URL of the submodules to point to your forked repositories. For example, for the frontend submodule:
+
+   .. code-block:: bash
+
+      cd frontend-v2
+      git remote set-url origin https://github.com/<your-username>/frontend-v2
+
+   If you prefer to use SSH instead of HTTPS, the command would be:
+
+   .. code-block:: bash
+
+      git remote set-url origin git@github.com:<your-username>/frontend-v2.git
+
+5. Optionally, you can also set up the upstream remote to keep your fork in sync with the original repository:
+
+   .. code-block:: bash
+
+      git remote add upstream https://github.com/choras-org/frontend-v2
+
+6. Finally, create a new branch for your changes:
+
+   .. code-block:: bash
+
+      git checkout -b my-feature-branch
+
+
+Quickstart developing
+---------------------
+
+To setup the development environment for the fronent follow these steps:
+
+1. Install `node.js <https://nodejs.org/en/>`_ on your machine.
+2. Once installed run the following commands navigated to the folder you want the CHORAS frontend to live:
+
+   .. code-block:: shell
+
+      git clone -b dev https://github.com/choras-org/frontend-v2.git
+      cd frontend-v2
+      npm install
+      npm run dev
+
+3. Go to `http://localhost:5173/ <http://localhost:5173/>`_ in your favourite browser and the user interface should be visible.
+4. If the projects are not loaded correctly or if you have trouble creating a new project, this means that you still need to get the backend up and running. Follow the instructions `here <https://choras.readthedocs.io/en/latest/includes/setup.html>`_.

--- a/docs/source/includes/contributing/frontend/setup_dev.rst
+++ b/docs/source/includes/contributing/frontend/setup_dev.rst
@@ -54,10 +54,10 @@ This allows you to freely develop and test your changes without affecting the ma
 Quickstart developing
 ---------------------
 
-To setup the development environment for the fronent follow these steps:
+To set up the development environment for the frontend, follow these steps:
 
 1. Install `node.js <https://nodejs.org/en/>`_ on your machine.
-2. Once installed run the following commands navigated to the folder you want the CHORAS frontend to live:
+2. Once installed, run the following commands while navigating to the folder where you want the CHORAS frontend to live:
 
    .. code-block:: shell
 

--- a/docs/source/includes/contributing/general/releasing.rst
+++ b/docs/source/includes/contributing/general/releasing.rst
@@ -25,22 +25,25 @@ are not considered for version increments.
 Updating the combined CHORAS version
 ====================================
 
-After tagging a new simulation-backend umbrella release (plain ``vX.Y.Z``), update
-the ``simulation-backend`` submodule pointer in the CHORAS umbrella repo to that tag
-and bump the combined CHORAS version:
+Whenever one or more components (``frontend-v2``, ``backend``, ``simulation-backend``)
+have a new tagged release that should become part of the next validated CHORAS
+combination, update their submodule pointer(s) in the CHORAS umbrella repo and bump
+the combined CHORAS version:
 
-1. Check out ``simulation-backend`` at the new tag:
+1. Check out each updated submodule at its new tag (repeat for every submodule
+   that changed — for ``simulation-backend``, use its own whole-repo tag, not an
+   individual simulation method's scoped tag):
 
    .. code-block:: console
 
-      $ git -C simulation-backend checkout vX.Y.Z
-      $ git add simulation-backend
+      $ git -C <submodule> checkout vX.Y.Z
+      $ git add <submodule>
 
 2. Commit and tag the umbrella repo:
 
    .. code-block:: console
 
-      $ git commit -m "Bump CHORAS version: update simulation-backend to vX.Y.Z"
+      $ git commit -m "Bump CHORAS version: update <submodule>(s) to vX.Y.Z"
       $ git tag vA.B.C
 
 3. Push:

--- a/docs/source/includes/contributing/general/releasing.rst
+++ b/docs/source/includes/contributing/general/releasing.rst
@@ -20,3 +20,31 @@ while MINOR and MAJOR changes are made against the develop branch (and consequen
 Note that PRs that only change documentation or examples are considered PATCH changes.
 Updates to the CI configuration or similar infrastructure which do not affect the API
 are not considered for version increments.
+
+
+Updating the combined CHORAS version
+====================================
+
+After tagging a new simulation-backend umbrella release (plain ``vX.Y.Z``), update
+the ``simulation-backend`` submodule pointer in the CHORAS umbrella repo to that tag
+and bump the combined CHORAS version:
+
+1. Check out ``simulation-backend`` at the new tag:
+
+   .. code-block:: console
+
+      $ git -C simulation-backend checkout vX.Y.Z
+      $ git add simulation-backend
+
+2. Commit and tag the umbrella repo:
+
+   .. code-block:: console
+
+      $ git commit -m "Bump CHORAS version: update simulation-backend to vX.Y.Z"
+      $ git tag vA.B.C
+
+3. Push:
+
+   .. code-block:: console
+
+      $ git push --follow-tags

--- a/docs/source/includes/contributing/simulation_method/releasing.rst
+++ b/docs/source/includes/contributing/simulation_method/releasing.rst
@@ -1,0 +1,134 @@
+Release Workflow
+================
+
+A reminder for the maintainers on how to release a new version.
+
+The ``simulation-backend`` repo has two release tracks:
+
+1. Independent **per-method releases** — each packaged simulation method (``de``, ``dg``, ``pyroomacoustics``, ``sparrowpy``, ``misuka``, ``modart``) is versioned independently with a scoped SemVer tag (e.g. ``dg-v1.2.0``). Run ``bump-my-version`` from **inside** the method's directory.
+2. **Umbrella releases** to release a new version bundling all simulation methods — the whole repo gets a plain ``vX.Y.Z`` tag whenever there are changes to any of the simulation methods or the configuration files in the repository. Run ``bump-my-version`` from the **repository root**.
+
+For the general versioning scheme, see the
+`versioning section <../general/releasing.html#versioning>`_
+in the general contributing guidelines.
+
+----
+
+Releasing a simulation method
+------------------------------
+
+Each of the simulation methods (e.g. ``de``, ``dg``, ``pyroomacoustics``, ...) is versioned independently.
+Tags are **scoped** to avoid ambiguity with each other and with the umbrella tag:
+``dg-v1.2.0``, ``de-v0.9.1``, etc.
+
+Patch releases are made directly on ``main``; minor and major releases are branched
+off ``develop`` and merged into ``main`` before tagging, following the same
+branch strategy as the backend. In case multiple PRs are planned for a single ``minor`` release,
+it might be worth considering creating a scoped ``develop`` branch such as ``develop/de``.
+
+Prepare the release
+~~~~~~~~~~~~~~~~~~~
+
+- Update the method's ``HISTORY.rst`` (inside ``<method>_method/``) and commit any
+  outstanding changes.
+- Run the method's test suite and make sure all tests pass.
+
+Incrementing the version number
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each method carries has an individual configuration for ``bumpversion`` section inside its
+``<method>_method/pyproject.toml``
+On use, bumpversion will set a method specific git tag (e.g. ``dg-v{new_version}``).
+
+**Run the bump command from inside the method's directory** so that
+``bump-my-version`` picks up the correct config:
+
+.. code-block:: console
+
+   $ cd dg_method
+   $ bump-my-version bump patch --verbose
+
+Replace ``dg_method`` with the relevant method directory and ``patch`` with
+``minor`` or ``major`` as appropriate.
+This updates the version in ``pyproject.toml``, commits the change, and creates the
+scoped git tag (e.g. ``dg-v0.1.1``) in one step.
+
+Publishing the new version
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Push the commit and the new scoped tag from the **repository root**:
+
+.. code-block:: console
+
+   $ git push --follow-tags
+
+Post-release steps
+~~~~~~~~~~~~~~~~~~
+
+Check whether the method's interface change also requires an update to
+``methods-config.json`` or any ``example_settings/*.json`` file.
+If so, make that update and bump the umbrella version as a **separate, deliberate
+step** — see `Releasing the simulation-backend umbrella`_ below.
+
+----
+
+Releasing the simulation-backend umbrella
+------------------------------------------
+
+The umbrella version (root ``pyproject.toml``, plain ``vX.Y.Z`` tag) tracks the
+**shared configuration** that no individual method owns:
+
+- ``methods-config.json`` — the method registry read by the backend at runtime.
+- ``example_settings/<method>_setting.json`` — per-method settings files.
+- The set of packaged methods itself (method added or removed).
+
+Bump this version whenever any of the above change — independent of any per-method
+version bump.
+A method's own ``bump-my-version`` run **never** touches this; the umbrella bump is
+always a deliberate, separate step.
+
+When to bump
+~~~~~~~~~~~~
+
+In addition to the `versioning section <../general/releasing.html#versioning>`_, you can consider the following:
+
+- **MAJOR** — breaking change to ``methods-config.json`` schema or a method's settings contract.
+- **MINOR** — new method added to ``methods-config.json``, or a backward-compatible change to a settings file or config entry.
+- **PATCH** — bug fix or correction in settings/config.
+
+Prepare the release
+~~~~~~~~~~~~~~~~~~~
+
+- Update ``HISTORY.rst`` at the **repository root** and commit any outstanding changes.
+- Confirm the relevant method's scoped release (if any) has already been tagged and
+  pushed before bumping the umbrella.
+
+Incrementing the version number
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Run from the **repository root** (the root ``pyproject.toml`` is the config target):
+
+.. code-block:: console
+
+   $ bump-my-version bump patch --verbose
+
+Replace ``patch`` with ``minor`` or ``major`` as appropriate.
+This updates the version in the root ``pyproject.toml``, commits the change, and
+creates the plain ``vX.Y.Z`` tag in one step.
+
+Publishing the new version
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Push the commit and tag:
+
+.. code-block:: console
+
+   $ git push --follow-tags
+
+Post-release steps
+~~~~~~~~~~~~~~~~~~
+
+After the umbrella tag is pushed, update the ``simulation-backend`` submodule pointer
+in the CHORAS umbrella repo to this new tag.
+See the `CHORAS versioning guide <../general/releasing.html#updating-the-combined-choras-version>`_
+for the full combined-CHORAS-version procedure.

--- a/docs/source/includes/contributing/simulation_method/releasing.rst
+++ b/docs/source/includes/contributing/simulation_method/releasing.rst
@@ -36,9 +36,9 @@ Prepare the release
 Incrementing the version number
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Each method carries has an individual configuration for ``bumpversion`` section inside its
-``<method>_method/pyproject.toml``
-On use, bumpversion will set a method specific git tag (e.g. ``dg-v{new_version}``).
+Each method has an individual configuration for the ``bumpversion`` section inside its
+``<method>_method/pyproject.toml``.
+When run, bumpversion will set a method-specific git tag (e.g. ``dg-v{new_version}``).
 
 **Run the bump command from inside the method's directory** so that
 ``bump-my-version`` picks up the correct config:

--- a/docs/source/includes/history.rst
+++ b/docs/source/includes/history.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../HISTORY.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,3 +24,9 @@ Below you can find instruction on how to set up CHORAS for users and developers,
    :caption: Contribution Guidelines
 
    includes/contributing.rst
+
+.. toctree::
+   :maxdepth: 1
+   :caption: History
+
+   includes/history.rst


### PR DESCRIPTION
This pull request  adds documentation on the release and development workflow documentation for all components of the project. It introduces guides for releasing the backend, simulation methods, and frontend, as well as instructions for setting up the frontend development environment. 

Additionally, it updates the general release guidelines of the umbrella repository when submodules are updated. 

**Release workflow documentation:**

* Added `releasing.rst` guides for the backend, simulation methods, and frontend, each detailing their respective versioning strategies, release commands, and post-release steps. 
* Updated the general release documentation to include a section on updating the combined CHORAS version when submodules are bumped, with step-by-step instructions for tagging and pushing the umbrella repo.

**Frontend development setup:**

* Added a Quickstart `setup_dev.rst` for the frontend, explaining how to fork, clone, set up submodules, and start the development server.
