### PR TITLE
CI: Create GitHub actions which create source distributions of CHORAS

### DIFF
--- a/.github/workflows/pr-bundle.yml
+++ b/.github/workflows/pr-bundle.yml
@@ -46,3 +46,22 @@ jobs:
           name: CHORAS-pr${{ github.event.number }}
           path: ${{ env.ARCHIVE }}
           retention-days: 7
+
+  test-build:
+    runs-on: ubuntu-latest
+    needs: bundle-pr
+
+    steps:
+      - name: Download bundle artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: CHORAS-pr${{ github.event.number }}
+
+      - name: Unpack bundle
+        run: unzip CHORAS-pr${{ github.event.number }}.zip
+
+      - name: Build with docker compose
+        # Runs only the build step — `docker compose up` starts long-running services
+        # and is not suitable for CI. A successful build proves the bundle is complete.
+        working-directory: CHORAS-pr${{ github.event.number }}
+        run: docker compose --profile sim_method build

--- a/.github/workflows/pr-bundle.yml
+++ b/.github/workflows/pr-bundle.yml
@@ -1,0 +1,48 @@
+# PR Bundle
+#
+# Runs on every pull request to produce a downloadable zip for local testing.
+# The archive is identical to the release bundle — same exclusions, same layout —
+# but named after the PR number and uploaded as a workflow artifact instead of
+# creating a GitHub Release.
+#
+# Download from the Actions run page → Artifacts section.
+
+name: PR Bundle
+
+on:
+  pull_request:
+
+jobs:
+  bundle-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Stage and bundle
+        run: |
+          ARCHIVE_NAME="CHORAS-pr${{ github.event.number }}"
+          STAGING="/tmp/${ARCHIVE_NAME}"
+          rsync -a \
+            --exclude=".git" \
+            --exclude=".github" \
+            --exclude=".venv" \
+            --exclude="node_modules" \
+            --exclude="__pycache__" \
+            --exclude=".pytest_cache" \
+            --exclude="uploads" \
+            --exclude="*.egg-info" \
+            . "$STAGING/"
+          cd /tmp
+          zip -r "${GITHUB_WORKSPACE}/${ARCHIVE_NAME}.zip" "${ARCHIVE_NAME}"
+          echo "ARCHIVE=${ARCHIVE_NAME}.zip" >> "$GITHUB_ENV"
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: CHORAS-pr${{ github.event.number }}
+          path: ${{ env.ARCHIVE }}
+          retention-days: 7

--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -38,13 +38,14 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
       - name: Read component versions
         id: versions
         run: |
-          # Read from the version source-of-truth files (pyproject.toml / package.json).
-          # git describe is not used: checkout@v4 only fetches the pinned commit for
-          # each submodule, not the remote tags, so --exact-match would always fail.
-          python3 - <<'PYEOF'
           import tomllib, json, os
           with open('backend/pyproject.toml', 'rb') as f:
               backend_ver = tomllib.load(f)['project']['version']

--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -106,6 +106,7 @@ jobs:
             --exclude=".pytest_cache" \
             --exclude="uploads" \
             --exclude="*.egg-info" \
+            --exclude="release_notes.md" \
             . "$STAGING/"
           cd /tmp
           zip -r "${GITHUB_WORKSPACE}/${ARCHIVE_NAME}.zip" "${ARCHIVE_NAME}"

--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -12,7 +12,9 @@
 #   3. Bundles the full source tree — minus dev artifacts (.git, .venv,
 #      node_modules, etc.) — into CHORAS-vX.Y.Z.zip, with a top-level
 #      directory so it unpacks cleanly.
-#   4. Creates a GitHub Release as a draft (publish manually after review).
+#   4. Unpacks the bundle on a fresh runner and runs `docker compose --profile sim_method build`
+#      to verify it is complete and buildable before publishing.
+#   5. Creates a GitHub Release as a draft (publish manually after review).
 #      Tags containing a hyphen (e.g. v1.0.0-rc.1) are flagged as pre-releases.
 #
 # The zip contains everything needed to build locally:
@@ -28,8 +30,6 @@ on:
 jobs:
   bundle-release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
       - name: Checkout with submodules
@@ -108,13 +108,62 @@ jobs:
             . "$STAGING/"
           cd /tmp
           zip -r "${GITHUB_WORKSPACE}/${ARCHIVE_NAME}.zip" "${ARCHIVE_NAME}"
-          echo "ARCHIVE=${ARCHIVE_NAME}.zip" >> "$GITHUB_ENV"
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: CHORAS-${{ github.ref_name }}
+          path: CHORAS-${{ github.ref_name }}.zip
+          retention-days: 7
+
+      - name: Upload release notes artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes-${{ github.ref_name }}
+          path: release_notes.md
+          retention-days: 7
+
+  test-build:
+    runs-on: ubuntu-latest
+    needs: bundle-release
+
+    steps:
+      - name: Download bundle artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: CHORAS-${{ github.ref_name }}
+
+      - name: Unpack bundle
+        run: unzip CHORAS-${{ github.ref_name }}.zip
+
+      - name: Build with docker compose
+        # Runs only the build step — `docker compose up` starts long-running services
+        # and is not suitable for CI. A successful build proves the bundle is complete.
+        working-directory: CHORAS-${{ github.ref_name }}
+        run: docker compose --profile sim_method build
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: test-build
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download bundle artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: CHORAS-${{ github.ref_name }}
+
+      - name: Download release notes artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes-${{ github.ref_name }}
 
       - name: Create draft release
         uses: softprops/action-gh-release@v2
         with:
           name: "CHORAS ${{ github.ref_name }}"
           body_path: release_notes.md
-          files: ${{ env.ARCHIVE }}
+          files: CHORAS-${{ github.ref_name }}.zip
           draft: true
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.github/workflows/release-bundle.yml
+++ b/.github/workflows/release-bundle.yml
@@ -1,0 +1,120 @@
+# Release Bundle
+#
+# Triggered by a vX.Y.Z tag push to the umbrella repo (the standard CHORAS
+# release procedure documented in docs/source/includes/contributing/general/releasing.rst).
+#
+# What it does:
+#   1. Checks out the umbrella repo with all three submodules (backend, frontend-v2,
+#      simulation-backend) at the commits pinned by the tag.
+#   2. Reads each component's version from its source-of-truth file
+#      (pyproject.toml / package.json) and extracts the matching changelog
+#      section from HISTORY.rst to build the release notes.
+#   3. Bundles the full source tree — minus dev artifacts (.git, .venv,
+#      node_modules, etc.) — into CHORAS-vX.Y.Z.zip, with a top-level
+#      directory so it unpacks cleanly.
+#   4. Creates a GitHub Release as a draft (publish manually after review).
+#      Tags containing a hyphen (e.g. v1.0.0-rc.1) are flagged as pre-releases.
+#
+# The zip contains everything needed to build locally:
+# unzip, then run CHORAS_BUILD.sh (Linux/macOS) or CHORAS_BUILD.bat (Windows).
+
+name: Release Bundle
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  bundle-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Read component versions
+        id: versions
+        run: |
+          # Read from the version source-of-truth files (pyproject.toml / package.json).
+          # git describe is not used: checkout@v4 only fetches the pinned commit for
+          # each submodule, not the remote tags, so --exact-match would always fail.
+          python3 - <<'PYEOF'
+          import tomllib, json, os
+          with open('backend/pyproject.toml', 'rb') as f:
+              backend_ver = tomllib.load(f)['project']['version']
+          with open('frontend-v2/package.json') as f:
+              frontend_ver = json.load(f)['version']
+          with open('simulation-backend/pyproject.toml', 'rb') as f:
+              sim_ver = tomllib.load(f)['project']['version']
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as out:
+              out.write(f'backend=v{backend_ver}\n')
+              out.write(f'frontend=v{frontend_ver}\n')
+              out.write(f'simulation_backend=v{sim_ver}\n')
+          PYEOF
+
+      - name: Write release notes
+        run: |
+          python3 - \
+            "${GITHUB_REF_NAME#v}" \
+            "${{ steps.versions.outputs.backend }}" \
+            "${{ steps.versions.outputs.frontend }}" \
+            "${{ steps.versions.outputs.simulation_backend }}" \
+            <<'PYEOF'
+          import re, sys
+          version, backend, frontend, simulation_backend = sys.argv[1:]
+          text = open("HISTORY.rst").read()
+          # Matches "0.1.0 (date)\n---...\n<content>" up to the next heading or EOF
+          pattern = rf"^{re.escape(version)} \([^)]+\)\n-+\n(.*?)(?=\n\S[^\n]*\n-+|\Z)"
+          m = re.search(pattern, text, re.MULTILINE | re.DOTALL)
+          changes = m.group(1).strip() if m else "_No changelog entry found for this version._"
+          lines = [
+              "## What's changed",
+              "",
+              changes,
+              "",
+              "## Component versions",
+              "",
+              "| Component | Tag |",
+              "|---|---|",
+              f"| Backend | {backend} |",
+              f"| Frontend | {frontend} |",
+              f"| Simulation Backend | {simulation_backend} |",
+              "",
+              "Build locally with `CHORAS_BUILD.sh` (Linux/macOS) or `CHORAS_BUILD.bat` (Windows) after unzipping.",
+          ]
+          with open("release_notes.md", "w") as f:
+              f.write("\n".join(lines) + "\n")
+          PYEOF
+
+      - name: Stage and bundle
+        run: |
+          ARCHIVE_NAME="CHORAS-${GITHUB_REF_NAME}"
+          STAGING="/tmp/${ARCHIVE_NAME}"
+          rsync -a \
+            --exclude=".git" \
+            --exclude=".github" \
+            --exclude=".venv" \
+            --exclude="node_modules" \
+            --exclude="__pycache__" \
+            --exclude=".pytest_cache" \
+            --exclude="uploads" \
+            --exclude="*.egg-info" \
+            . "$STAGING/"
+          cd /tmp
+          zip -r "${GITHUB_WORKSPACE}/${ARCHIVE_NAME}.zip" "${ARCHIVE_NAME}"
+          echo "ARCHIVE=${ARCHIVE_NAME}.zip" >> "$GITHUB_ENV"
+
+      - name: Create draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "CHORAS ${{ github.ref_name }}"
+          body_path: release_notes.md
+          files: ${{ env.ARCHIVE }}
+          draft: true
+          prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
The source distributions include all submodules. 
They can be used without git. 

The release bundle action further creates a GitHub release on tagged commits